### PR TITLE
Fix syntax of set() in webOS.cmake

### DIFF
--- a/webOS/webOS.cmake
+++ b/webOS/webOS.cmake
@@ -540,7 +540,7 @@ macro(_webos_set_component_version version_string)
 			                    " version (${version_string})")
 		endif()
 	else()
-		set(WEBOS_COMPONENT_VERSION ${version_string} CACHE FORCE "The version of the component")
+		set(WEBOS_COMPONENT_VERSION ${version_string} CACHE STRING "The version of the component" FORCE)
 	endif()
 endmacro()
 


### PR DESCRIPTION
Using CMake 3.26.4, I was getting the following warning when generating Makefiles:
```
CMake Warning (dev) at webOS/webOS.cmake:543 (set):
  implicitly converting 'FORCE' to 'STRING' type.
Call Stack (most recent call first):
  webOS/webOS.cmake:584 (_webos_set_component_version)
  CMakeLists.txt:32 (webos_component)
```

This is line 543 in `webOS/webOS.cmake`:
```cmake
set(WEBOS_COMPONENT_VERSION ${version_string} CACHE FORCE "The version of the component")
```

I'm certainly no CMake expert, but looking at the [documentation for `set()`](https://cmake.org/cmake/help/latest/command/set.html) (or for [version 2.8.12](https://cmake.org/cmake/help/v2.8.12/cmake.html#command:set)), it looks like `FORCE` needs to be the last argument. Here, it's taking the place of the type. According to the warning message, it's being interpreted as a type of `STRING` anyway. However, because it's being treated as a type (and basically ignored), I don't think `FORCE` is having any effect.

To avoid the warning, I explicitly specified the `STRING` type and moved `FORCE` to the end.